### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,53 @@
+declare module 'eth-query' {
+  // What it says on the tin. We omit `null`, as that value is used for a
+  // successful response to indicate a lack of an error.
+  type EverythingButNull =
+    | string
+    | number
+    | boolean
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    | object
+    | symbol
+    | undefined;
+
+  type ProviderSendAsyncResponse<Result> = {
+    error?: { message: string };
+    result?: Result;
+  };
+
+  type ProviderSendAsyncCallback<Result> = (
+    error: unknown,
+    response: ProviderSendAsyncResponse<Result>,
+  ) => void;
+
+  type Provider = {
+    sendAsync<Params, Result>(
+      payload: SendAsyncPayload<Params>,
+      callback: ProviderSendAsyncCallback<Result>,
+    ): void;
+  };
+
+  type SendAsyncPayload<Params> = {
+    id: number;
+    jsonrpc: '2.0';
+    method: string;
+    params: Params;
+  };
+
+  type SendAsyncCallback<Result> = (
+    ...args:
+      | [error: EverythingButNull, result: undefined]
+      | [error: null, result: Result]
+  ) => void;
+
+  export default class EthQuery {
+    constructor(provider: Provider);
+
+    sendAsync<Params, Result>(
+      opts: Partial<SendAsyncPayload<Params>>,
+      callback: SendAsyncCallback<Result>,
+    ): void;
+
+    [method: string]: (...args: any[]) => void;
+  }
+}


### PR DESCRIPTION
TypeScript will refuse to build a project that relies on `eth-query`, as it lacks type definitions. We have previously gotten around this in the extension and in `core` by supplying those type definitions directly in the project itself, but this is causing issues especially for the Snaps team, who now wish to use `@metamask/controller-utils`, which names `eth-query` as a dependency.

This commit copies the type definitions from the `core` monorepo into this repo. They were previously copied from the extension, so they have been battle-tested pretty well now.

Fixes #1.
Fixes https://github.com/MetaMask/core/issues/1471.