### PR TITLE
Expose type definitions file to consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "license": "ISC",
   "author": "",
-  "main": "index.js",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",
     "lint:changelog": "auto-changelog validate",


### PR DESCRIPTION
We now have a type definitions file, but consumers will not be able to use it unless a `types` field that points to it is present in the manifest. This fixes that.