### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
     "url": "https://github.com/MetaMask/eth-query.git"
   },
   "license": "ISC",
-  "author": "",
+  "sideEffects": false,
   "main": "./index.js",
   "types": "./index.d.ts",
+  "files": [
+    "./index.js",
+    "./index.d.ts"
+  ],
   "scripts": {
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",
     "lint:changelog": "auto-changelog validate",
@@ -48,8 +52,13 @@
     "prettier-plugin-packagejson": "^2.3.0",
     "typescript": "~4.8.4"
   },
+  "packageManager": "yarn@3.2.1",
   "engines": {
     "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
- Add `files` to ensure that only files we care about (the JavaScript and TypeScript type definition file) are included in the published package
- Remove `author` field (as the module template doesn't include it, and it's empty anyway)
- Add missing `sideEffects`, `packageManager`, and `publishConfig` fields

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
