### PR TITLE
Fix type definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'eth-query' {
+declare module '@metamask/eth-query' {
   // What it says on the tin. We omit `null`, as that value is used for a
   // successful response to indicate a lack of an error.
   type EverythingButNull =


### PR DESCRIPTION
The module that is declared in the type definitions file needs to match the name of the package that's in the manifest. Otherwise TypeScript will not be able to find the types for this package correctly by following the import.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
