### PR TITLE
Align types with @metamask/eth-json-rpc-provider

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,16 @@ declare module '@metamask/eth-query' {
     | symbol
     | undefined;
 
+  type Json =
+    | null
+    | boolean
+    | number
+    | string
+    | Json[]
+    | { [prop: string]: Json };
+
+  type JsonRpcParams = Json[] | Record<string, Json>;
+
   type ProviderSendAsyncResponse<Result> = {
     error?: { message: string };
     result?: Result;
@@ -21,13 +31,13 @@ declare module '@metamask/eth-query' {
   ) => void;
 
   type Provider = {
-    sendAsync<Params, Result>(
+    sendAsync<Params extends JsonRpcParams, Result>(
       payload: SendAsyncPayload<Params>,
       callback: ProviderSendAsyncCallback<Result>,
     ): void;
   };
 
-  type SendAsyncPayload<Params> = {
+  type SendAsyncPayload<Params extends JsonRpcParams> = {
     id: number;
     jsonrpc: '2.0';
     method: string;
@@ -43,7 +53,7 @@ declare module '@metamask/eth-query' {
   export default class EthQuery {
     constructor(provider: Provider);
 
-    sendAsync<Params, Result>(
+    sendAsync<Params extends JsonRpcParams, Result>(
       opts: Partial<SendAsyncPayload<Params>>,
       callback: SendAsyncCallback<Result>,
     ): void;


### PR DESCRIPTION
Currently, passing an instance of SafeEventEmitterProvider to the EthQuery constructor produces a type error. This is happening because the `Provider` type that this package defines allows the `params` property of the JSON-RPC request object to be anything, whereas in the SafeEventEmitterProvider interface, it has to be JSON-compatible. In other words, the provider that this package expects isn't compliant with a "proper" provider.

To fix this, this commit manually copies the `Json` and `JsonRpcParams` types from `@metamask/utils` to avoid a direct dependency. This is a temporary solution to prevent this type error from spreading within the `core` codebase. We will investigate a more overarching solution later.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

See: https://github.com/MetaMask/core/issues/1823